### PR TITLE
fixed deprecated configuration. Now compatible with SF5

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,10 +17,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fcm_http');
+        $treeBuilder = new TreeBuilder('fcm_http');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
             ->scalarNode('autentication_api_key')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('api_url')->defaultValue('https://fcm.googleapis.com/fcm/send')->end()


### PR DESCRIPTION
Fixed deprecation:
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "fcm_http" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.